### PR TITLE
Use Explicit General Error Type

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisError.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisError.scala
@@ -1,0 +1,21 @@
+package io.chrisdavenport.rediculous
+
+/** Indicates a Error while processing for Rediculous */
+trait RedisError extends RuntimeException {
+
+  /** Provides a message appropriate for logging. */
+  def message: String
+
+  /* Overridden for sensible logging of the failure */
+  final override def getMessage: String = message
+
+  def cause: Option[Throwable]
+
+  final override def getCause: Throwable = cause.orNull
+}
+
+object RedisError {
+  final case class Generic(message: String) extends RedisError{
+    val cause: Option[Throwable] = None
+  }
+}

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
@@ -55,7 +55,7 @@ object RedisResult extends RedisResultLowPriority{
         case "list" => RedisProtocol.RedisType.List
         case "set" => RedisProtocol.RedisType.Set
         case "zset" => RedisProtocol.RedisType.ZSet
-        case _ => throw new Throwable(s"Rediculous: Unhandled red type: $value")
+        case _ => throw RedisError.Generic(s"Rediculous: Unhandled red type: $value")
       })
       case r => Left(r)
     }

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisTransaction.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisTransaction.scala
@@ -125,7 +125,7 @@ object RedisTransaction {
         ), key).map{_.flatMap{_.last match {
           case Resp.Array(Some(a)) => f(a).fold[TxResult[A]](e => TxResult.Error(e.toString), TxResult.Success(_)).pure[F]
           case Resp.Array(None) => (TxResult.Aborted: TxResult[A]).pure[F]
-          case other => ApplicativeError[F, Throwable].raiseError(new Throwable(s"EXEC returned $other"))
+          case other => ApplicativeError[F, Throwable].raiseError(RedisError.Generic(s"EXEC returned $other"))
         }}}
       })
     }

--- a/core/src/main/scala/io/chrisdavenport/rediculous/Resp.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/Resp.scala
@@ -13,7 +13,7 @@ object Resp {
   sealed trait RespParserResult[+A]
   final case class ParseComplete[A](value: A, rest: SArray[Byte]) extends RespParserResult[A]
   final case class ParseIncomplete(arr: SArray[Byte]) extends RespParserResult[Nothing]
-  final case class ParseError(message: String, cause: Option[Throwable]) extends Throwable(message, cause.orNull) with RespParserResult[Nothing]
+  final case class ParseError(message: String, cause: Option[Throwable]) extends RedisError with RespParserResult[Nothing]
   private[Resp] val CR = '\r'.toByte
   private[Resp] val LF = '\n'.toByte
   private[Resp] val Plus = '+'.toByte
@@ -104,7 +104,10 @@ object Resp {
     }
   }
   // First Byte is -
-  case class Error(value: String) extends Throwable(s"Resp Error- $value") with Resp
+  case class Error(value: String) extends RedisError with Resp{
+    def message: String = s"Resp Error- $value"
+    val cause: Option[Throwable] = None
+  }
   object Error {
     def encode(error: Error): SArray[Byte] = 
       SArray(Minus) ++ error.value.getBytes(StandardCharsets.UTF_8) ++ CRLF

--- a/core/src/main/scala/io/chrisdavenport/rediculous/cluster/ClusterCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/cluster/ClusterCommands.scala
@@ -44,7 +44,7 @@ object ClusterCommands {
       } else None
     }.flatMap{
       case Some(a) => Sync[F].pure(a)
-      case None => Sync[F].raiseError[(String, Int)](new Throwable("Rediculous: No Servers Available"))
+      case None => Sync[F].raiseError[(String, Int)](RedisError.Generic("Rediculous: No Servers Available"))
     }
   }
   object ClusterSlots {


### PR DESCRIPTION
- Can later add additional refinements, but its valuable that now these can all be handled via 

```
f.handleError{
 case e: RedisError => ...
}
```