### PR TITLE
Prevent Deadlock Queue Fill

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -25,7 +25,16 @@ object RedisConnection{
   ) extends RedisConnection[F]
   private case class DirectConnection[F[_]](socket: Socket[F]) extends RedisConnection[F]
 
-  private case class Cluster[F[_]](queue: Chunk[(Deferred[F, Either[Throwable, Resp]], Option[String], Option[(String, Int)], Int, Resp)] => F[Unit]) extends RedisConnection[F]
+  private case class Cluster[F[_]](queue: Queue[F, Chunk[(Deferred[F, Either[Throwable, Resp]], Option[String], Option[(String, Int)], Int, Resp)]]) extends RedisConnection[F]
+
+
+  sealed trait DirectBy
+  object DirectBy {
+    case object ToAny extends DirectBy
+    case object Broadcast extends DirectBy
+    final case class Server(host: String, port: Int) extends DirectBy
+    final case class Key(key: String) extends DirectBy
+  }
 
   // Guarantees With Socket That Each Call Receives a Response
   // Chunk must be non-empty but to do so incurs a penalty
@@ -75,7 +84,7 @@ object RedisConnection{
         }   
       }
       case Cluster(queue) => chunk.traverse(resp => Deferred[F, Either[Throwable, Resp]].map((_, key, None, 0, resp))).flatMap{ c => 
-        queue(c).as {
+        queue.enqueue1(c).as {
           c.traverse(_._1.get).flatMap(_.sequence.traverse(l => Sync[F].delay(l.toNel.getOrElse(throw RedisError.Generic("Rediculous: Impossible Return List was Empty but we guarantee output matches input"))))).rethrow
         }
       }   
@@ -197,8 +206,10 @@ object RedisConnection{
       sockets <- Resource.liftF(keypool.take((host, port)).map(_.value._1).map(DirectConnection(_)).use(ClusterCommands.clusterslots[Redis[F, *]].run(_)))
       refTopology <- Resource.liftF(Ref[F].of(sockets))
       queue <- Resource.liftF(Queue.bounded[F, Chunk[(Deferred[F, Either[Throwable,Resp]], Option[String], Option[(String, Int)], Int, Resp)]](maxQueued))
-      cluster = Cluster(queue.enqueue1)
-      refreshTopology = ClusterCommands.clusterslots[Redis[F, *]].run(cluster).flatMap(refTopology.set)
+      cluster = Cluster(queue)
+      refreshTopology = refTopology.get.flatMap(_.random).flatMap{ case (host, port) =>
+        keypool.take((host, port)).map(_.value._1).map(DirectConnection(_)).use(ClusterCommands.clusterslots[Redis[F, *]].run(_))
+      }.flatMap(s => refTopology.set(s))
       _ <- 
           queue.dequeue.chunks.map{chunkChunk =>
             val chunk = chunkChunk.flatten
@@ -223,8 +234,15 @@ object RedisConnection{
                         case (ref, i) => 
                           val (toSet, key, _, retries, initialCommand) = rest(i)
                           ref match {
-                            case Resp.Error(s) if (s.startsWith("MOVED") && retries <= 5)  => // MOVED 1234-2020 127.0.0.1:6381
-                              (refreshTopology >> cluster.queue(Chunk.singleton((toSet, key, extractServer(s), retries + 1, initialCommand)))).start.void // We only end up here max 
+                            case e@Resp.Error(s) if (s.startsWith("MOVED") && retries <= 5)  => // MOVED 1234-2020 127.0.0.1:6381
+                              refreshTopology.attempt.void >>
+                              // Offer To Have it reprocessed. 
+                              // If the queue is full return the error to the user
+                              cluster.queue.offer1(Chunk.singleton((toSet, key, extractServer(s), retries + 1, initialCommand)))
+                                .ifM( 
+                                  Applicative[F].unit,
+                                  toSet.complete(Either.right(e))
+                                )
                             case e@Resp.Error(s) if (s.startsWith("ASK") && retries <= 5) => // ASK 1234-2020 127.0.0.1:6381
                               val serverRedirect = extractServer(s)
                               serverRedirect match {
@@ -233,8 +251,13 @@ object RedisConnection{
                                     val asking = (d, key, s, 6, Resp.renderRequest(NonEmptyList.of("ASKING"))) // Never Repeat Asking
                                     val repeat = (toSet, key, s, retries + 1, initialCommand)
                                     val chunk = Chunk(asking, repeat)
-                                    cluster.queue(chunk)
-                                  }.start.void
+                                    cluster.queue.offer1(chunk) // Offer To Have it reprocessed. 
+                                      //If the queue is full return the error to the user
+                                      .ifM(
+                                        Applicative[F].unit,
+                                        toSet.complete(Either.right(e))
+                                      )
+                                  }
                                 case None => 
                                   toSet.complete(Either.right(e))
                               }

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -27,15 +27,6 @@ object RedisConnection{
 
   private case class Cluster[F[_]](queue: Queue[F, Chunk[(Deferred[F, Either[Throwable, Resp]], Option[String], Option[(String, Int)], Int, Resp)]]) extends RedisConnection[F]
 
-
-  sealed trait DirectBy
-  object DirectBy {
-    case object ToAny extends DirectBy
-    case object Broadcast extends DirectBy
-    final case class Server(host: String, port: Int) extends DirectBy
-    final case class Key(key: String) extends DirectBy
-  }
-
   // Guarantees With Socket That Each Call Receives a Response
   // Chunk must be non-empty but to do so incurs a penalty
   private[rediculous] def explicitPipelineRequest[F[_]: MonadError[*[_], Throwable]](socket: Socket[F], calls: Chunk[Resp], maxBytes: Int = 8 * 1024 * 1024, timeout: Option[FiniteDuration] = 5.seconds.some): F[List[Resp]] = {


### PR DESCRIPTION
So I woke up this morning thinking about this condition.

Given a bounded Clustered Queue, we could end up where our message processor is blocked waiting for a messge processor to unblock the moved or ask commands.

Instead we need to return the processors to operating on the pool. This creates the possibility of temporary thread leakage (for messages that only happen during temporary cluster rebalancing), however this allows us to work on new messages on any worker size meaning we will eventually clear the pool.


I tried a lot of different alternatives, but since we need to wait on the response from the redis server for moved shifts, this appears to be the safest way, and is MUCH safer than what we were doing previously. As we need to ensure work continues through to the server.
