### PR TITLE
Support Redis Streams (XREAD, XADD)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 val catsV = "2.6.1"
-val catsEffectV = "3.2.0"
+val catsEffectV = "3.3.0"
 // val fs2V = "3.0.6"
-val fs2V = "3.2.0"
+val fs2V = "3.2.3"
 
 val munitCatsEffectV = "1.0.5"
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 val catsV = "2.6.1"
 val catsEffectV = "3.2.0"
 // val fs2V = "3.0.6"
-val fs2V = "3.1.0"
+val fs2V = "3.2.0"
 
 val munitCatsEffectV = "1.0.5"
 

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -255,7 +255,7 @@ object RedisCommands {
     case class From(stream: String, offset: String) extends StreamOffset 
   }
 
-  def xread[F[_]: RedisCtx](streams: Set[StreamOffset], xreadOpts: XReadOpts = XReadOpts.default): F[List[List[(String, List[List[(String, List[(String, String)])]])]]] = {
+  def xread[F[_]: RedisCtx](streams: Set[StreamOffset], xreadOpts: XReadOpts = XReadOpts.default): F[Option[List[List[(String, List[List[(String, List[(String, String)])]])]]]] = {
     val block = xreadOpts.blockMillisecond.toList.flatMap(l => List("BLOCK", l.encode))
     val count = xreadOpts.count.toList.flatMap(l => List("COUNT", l.encode))
     val noAck = Alternative[List].guard(xreadOpts.noAck).as("NOACK")

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -40,8 +40,11 @@ object RedisConnection{
         ApplicativeError[F, Throwable].raiseError[List[Resp]](RedisError.Generic("Rediculous: Terminated Before reaching Equal size"))
       case Some(bytes) => 
         Resp.parseAll(lastArr.toArray ++ bytes.toIterable) match {
-          case e@Resp.ParseError(_, _) => ApplicativeError[F, Throwable].raiseError[List[Resp]](e)
-          case Resp.ParseIncomplete(arr) => getTillEqualSize(acc, arr)
+          case e@Resp.ParseError(_, _) => 
+            ApplicativeError[F, Throwable].raiseError[List[Resp]](e)
+          case Resp.ParseIncomplete(arr) => 
+            println(s"INCOMPLETE")
+            getTillEqualSize(acc, lastArr.toArray ++ bytes.toIterable)
           case Resp.ParseComplete(value, rest) => 
             if (value.size + acc.foldMap(_.size) === calls.size) (value ::acc ).reverse.flatten.pure[F]
             else getTillEqualSize(value :: acc, rest)

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
@@ -1,0 +1,62 @@
+package io.chrisdavenport.rediculous
+
+import cats.implicits._
+import fs2.{Stream, Pipe}
+import scala.concurrent.duration.Duration
+import RedisCommands.{XAddOpts, XReadOpts, StreamOffset, Trimming, xadd, xread}
+import cats.effect._
+
+final case class XAddMessage(key: String, body: Map[String, String], approxMaxlen: Option[Long] = None)
+final case class XReadMessage(id: MessageId, key: String, body: Map[String, String])
+final case class MessageId(value: String) extends AnyVal
+
+trait RedisStream[F[_]] {
+  def append(messages: List[XAddMessage]): F[List[MessageId]]
+
+  def read(
+    keys: Set[String],
+    chunkSize: Int,
+    initialOffset: String => StreamOffset = StreamOffset.All,
+    block: Duration = Duration.Zero,
+    count: Option[Long] = None
+  ): Stream[F, XReadMessage]
+}
+
+object RedisStream {
+  /**
+   * Create a RedisStream from a connection.
+   * 
+   **/
+  def fromConnection[F[_]: Async](connection: RedisConnection[F]): RedisStream[F] = new RedisStream[F] {
+    def append(messages: List[XAddMessage]): F[List[MessageId]] = {
+      messages
+        .traverse{ msg => 
+          val opts = msg.approxMaxlen.map(l => XAddOpts.default.copy(maxLength = l.some, trimming = Trimming.Approximate.some))
+          xadd[RedisPipeline](msg.key, msg.body, opts getOrElse XAddOpts.default).map(MessageId.apply)
+        }
+        .pipeline[F]
+        .run(connection)
+    }
+
+    private val nextOffset: String => XReadMessage => StreamOffset = 
+      key => msg => StreamOffset.From(key, msg.id.value)
+
+    private val offsetsByKey: List[XReadMessage] => Map[String, Option[StreamOffset]] =
+      list => list.groupBy(_.key).map { case (k, values) => k -> values.lastOption.map(nextOffset(k)) }
+
+    def read(keys: Set[String], chunkSize: Int, initialOffset: String => StreamOffset, block: Duration, count: Option[Long]): Stream[F, XReadMessage] = {
+      val initial = keys.map(k => k -> initialOffset(k)).toMap
+      val opts = XReadOpts.default.copy(blockMillisecond = block.toMillis.some, count = count)
+      Stream.eval(Ref.of[F, Map[String, StreamOffset]](initial)).flatMap { ref =>
+        (for {
+          offsets <- Stream.eval(ref.get)
+          list <- Stream.eval(xread(offsets.values.toSet, opts).run(connection)).flattenOption
+          messages = list.flatten.map { case (k, l) => l.flatten.map{case (id, values) => XReadMessage(MessageId(id), k, values.toMap)}}.flatten
+          newOffsets = offsetsByKey(messages).collect { case (key, Some(value)) => key -> value }.toList
+          _ <- Stream.eval(newOffsets.map { case (k, v) => ref.update(_.updated(k, v)) }.sequence)
+          result <- Stream.fromIterator(messages.iterator, chunkSize)
+        } yield result).repeat
+      }
+    }
+  }
+}

--- a/core/src/main/scala/io/chrisdavenport/rediculous/Resp.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/Resp.scala
@@ -56,7 +56,8 @@ object Resp {
     def loop(arr: SArray[Byte]): RespParserResult[List[Resp]] = {
       if (arr.isEmpty) ParseComplete(listBuffer.toList, arr)
       else parse(arr) match {
-        case ParseIncomplete(out) => ParseComplete(listBuffer.toList, out)
+        case ParseIncomplete(out) => ParseIncomplete(out)
+        // case ParseIncomplete(out) => ParseComplete(listBuffer.toList, out)
         case ParseComplete(value, rest) =>
           listBuffer.append(value)
           loop(rest)

--- a/examples/src/main/scala/StreamExample.scala
+++ b/examples/src/main/scala/StreamExample.scala
@@ -62,7 +62,7 @@ object StreamProducerExample extends IOApp {
 
         val producer = 
           Stream
-            .repeatEval(IO.pure(Map("test" -> "test")))
+            .repeatEval(randomMessage)
             .map(XAddMessage(mystream, _))
             .chunkMin(10000)
             .flatMap{ chunk => 

--- a/examples/src/main/scala/StreamProducerExample.scala
+++ b/examples/src/main/scala/StreamProducerExample.scala
@@ -1,0 +1,86 @@
+import io.chrisdavenport.rediculous._
+import java.util.concurrent.TimeoutException
+import scala.collection.immutable.Queue
+import scala.concurrent.duration._
+import scala.util.Random
+import cats.effect._
+import cats.implicits._
+import fs2._
+import fs2.timeseries.{TimeStamped, TimeSeries}
+import fs2.io.net._
+import com.comcast.ip4s._
+
+object StreamRate {
+  def rate[A] =
+    TimeStamped.withPerSecondRate[Option[Chunk[A]], Float](_.map(chunk => chunk.size.toFloat).getOrElse(0.0f))
+
+  def averageRate[A] =
+    rate[A].andThen(Scan.stateful1(Queue.empty[Float]) { 
+      case (q, tsv @ TimeStamped(_, Right(_))) => (q, tsv)
+      case (q, TimeStamped(t, Left(sample))) => 
+        val q2 = (sample +: q).take(10)
+        val average = q2.sum / q2.size
+        (q, TimeStamped(t, Left(average)))
+    })
+
+  implicit class Logger[F[_]: Temporal, A](input: Stream[F, A]) {
+    def logAverageRate(logger: Float => F[Unit]): Stream[F, A] =
+      TimeSeries.timePulled(input.chunks, 1.second, 1.second)
+        .through(averageRate.toPipe)
+        .flatMap {
+          case TimeStamped(_, Left(rate)) => Stream.exec(logger(rate))
+          case TimeStamped(_, Right(Some(chunk))) => Stream.chunk(chunk)
+          case TimeStamped(_, Right(None)) => Stream.empty
+        }
+  }
+}
+
+object StreamProducerExample extends IOApp {
+  import StreamRate._
+
+  def putStrLn[A](a: A): IO[Unit] = IO(println(a))
+
+  def randomMessage: IO[Map[String, String]] = {
+    val rndKey   = IO(Random.nextInt(1000).toString)
+    val rndValue = IO(Random.nextString(10))
+    (rndKey, rndValue).parMapN { case (k, v) =>
+      Map(k -> v)
+    }
+  }
+
+  def run(args: List[String]): IO[ExitCode] = {
+    val r = for {
+      // maxQueued: How many elements before new submissions semantically block. Tradeoff of memory to queue jobs. 
+      // Default 10000 is good for small servers. But can easily take 100,000.
+      // workers: How many threads will process pipelined messages.
+      connection <- RedisConnection.queued[IO].withHost(host"localhost").withPort(port"6379").withMaxQueued(maxQueued = 10000).withWorkers(workers = 2).build
+    } yield connection
+
+    r
+      .flatMap{ client => 
+        Stream
+          .awakeEvery[IO](10.micro)
+          .evalMap(_ => randomMessage)
+          .groupWithin(10000, 1.milli)
+          .evalMap{ chunk => 
+            // Send a Single Set of Pipelined Commands to the Redis Server
+            val r = chunk.traverse(body => RedisCommands.xadd[RedisPipeline]("mystream", body))
+            val multi = r.pipeline[IO]
+            multi.run(client)
+          }
+          .unchunks
+          .logAverageRate(rate => IO.println(s"Producer rate: $rate"))
+          .compile
+          .drain
+          .background
+      }
+      .use(combined => IO.never)
+      .redeem(
+        { t =>
+          IO.println(s"Error: $t, Something went wrong")
+          ExitCode(1)
+        },
+        _ => ExitCode.Success
+      )
+  }
+}


### PR DESCRIPTION
This adds support for xadd, xread commands with an example. 

Running it i get
```
sbt:rediculous> examplesJVM/runMain StreamProducerExample
[info] compiling 1 Scala source to /Users/swoorup.joshi/github/rediculous/examples/.jvm/target/scala-2.13/classes ...
[info] running (fork) StreamProducerExample 
[info] Producer rate: 4592.0
[info] Producer rate: 13671.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 10000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 20000.0
[info] Producer rate: 10000.0
```