### PR TITLE
Fix an error with continuous subscription

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.2" // your current series x.y
+ThisBuild / tlBaseVersion := "0.3" // your current series x.y
 
 ThisBuild / organization := "io.chrisdavenport"
 ThisBuild / organizationName := "Christopher Davenport"

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -322,6 +322,22 @@ object RedisCommands {
     RedisCtx[F].unkeyed(NEL("XREAD", block ::: count ::: noAck ::: streamPairs))
   }
 
+  def xrange[F[_]: RedisCtx](stream: String, startOpt: Option[String] = None, endOpt: Option[String] = None, countOpt: Option[Int] = None): F[Option[List[StreamsRecord]]] = {
+    val start = List(startOpt.getOrElse("-"))
+    val end = List(endOpt.getOrElse("+"))
+    val count = countOpt.toList.flatMap(l => List("COUNT", l.encode))
+
+    RedisCtx[F].unkeyed(NEL("XRANGE", stream :: start ::: end ::: count))
+  }
+
+  def xrevrange[F[_]: RedisCtx](stream: String, endOpt: Option[String] = None, startOpt: Option[String] = None, countOpt: Option[Int] = None): F[Option[List[StreamsRecord]]] = {
+    val end = List(endOpt.getOrElse("+"))
+    val start = List(startOpt.getOrElse("-"))
+    val count = countOpt.toList.flatMap(l => List("COUNT", l.encode))
+
+    RedisCtx[F].unkeyed(NEL("XREVRANGE", stream :: end ::: start ::: count))
+  }
+
   def xgroupcreate[F[_]: RedisCtx](stream: String, groupName: String, startId: String): F[Status] = 
     RedisCtx[F].unkeyed(NEL.of("XGROUP", "CREATE", stream, groupName, startId))
 

--- a/examples/src/main/scala/StreamsExample.scala
+++ b/examples/src/main/scala/StreamsExample.scala
@@ -35,7 +35,7 @@ object StreamRate {
   }
 }
 
-object StreamProducerExample extends IOApp {
+object StreamExample extends IOApp {
   import StreamRate._
 
   def randomMessage: IO[List[(String, String)]] = {


### PR DESCRIPTION
Continuous subscription was not being updated correctly as it was never getting the offset correctly from the response. (Likely lost during the initial refactor).

Also added a test, which tries to request more records than present eventually timing out. This would originally return repeated records from the beginning as the offsets were never updated.

Also added xrange and xrevrange as a bonus.