### PR TITLE
Fix multiple subscriptions on redis streams

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
@@ -1,7 +1,7 @@
 package io.chrisdavenport.rediculous
 
 import cats.implicits._
-import fs2.{Stream, Pipe, Chunk}
+import fs2.{Stream, Chunk}
 import scala.concurrent.duration.Duration
 import RedisCommands.{XAddOpts, XReadOpts, StreamOffset, Trimming, xadd, xread}
 import cats.effect._

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisStream.scala
@@ -41,7 +41,7 @@ object RedisStream {
       key => msg => StreamOffset.From(key, msg.recordId)
 
     private val offsetsByKey: List[RedisCommands.XReadResponse] => Map[String, Option[StreamOffset]] =
-      list => list.groupBy(_.stream).map { case (k, values) => k -> values.flatMap(_.records).lastOption.map(nextOffset(k)) }
+      list => list.groupBy(_.stream).map { case (k, values) => k -> values.lastOption.flatMap(_.records.lastOption).map(nextOffset(k)) }
 
     def read(keys: Set[String],  initialOffset: String => StreamOffset, block: Duration, count: Option[Long]): Stream[F, RedisCommands.XReadResponse] = {
       val initial = keys.map(k => k -> initialOffset(k)).toMap

--- a/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
@@ -28,7 +28,7 @@ class RedisStreamSpec extends CatsEffectSuite {
       (hostS, portI) = t
       host <- Resource.eval(Host.fromString(hostS).liftTo[IO](new Throwable("Invalid Host")))
       port <- Resource.eval(Port.fromInt(portI).liftTo[IO](new Throwable("Invalid Port")))
-      connection <- RedisConnection.pool[IO].withHost(host).withPort(port).build
+      connection <- RedisConnection.queued[IO].withHost(host).withPort(port).build
     } yield connection 
     
   )
@@ -51,7 +51,6 @@ class RedisStreamSpec extends CatsEffectSuite {
       rStream.read(Set("foo")).take(1).compile.lastOrError
 
     }.map{ xrr => 
-      val i = xrr.stream
       assertEquals(xrr.stream, "foo")
       val i2 = xrr.records.flatMap(sr => sr.keyValues)
       assertEquals(i2.toSet, messages.toList.flatMap(_.body).toSet)
@@ -79,6 +78,28 @@ class RedisStreamSpec extends CatsEffectSuite {
     }.map{ resps => 
       val records = resps.flatMap(_.records).flatMap(_.keyValues.map(_._1))
       assertEquals(records, List("1", "2", "3"))
+    }
+  }
+
+  test("consume messages from multiple streams"){ //connection => 
+    val messages = fs2.Chunk(
+      RedisStream.XAddMessage("baf", List("1" -> "1")),
+      RedisStream.XAddMessage("baz", List("2" -> "2")),
+      RedisStream.XAddMessage("bar", List("3" -> "3")),
+    )
+    redisConnection().flatMap{connection => 
+      
+      val rStream = RedisStream.fromConnection(connection)
+      rStream.append(messages) >>
+      rStream
+        .read(Set("baf", "baz", "bar"), stream => RedisCommands.StreamOffset.From(stream, "0"))
+        .take(3)
+        .compile
+        .toList
+
+    }.map{ resps => 
+      val records = resps.flatMap(_.records).flatMap(_.keyValues.map(_._1)).toSet
+      assertEquals(records, Set("1", "2", "3"))
     }
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
@@ -86,20 +86,23 @@ class RedisStreamSpec extends CatsEffectSuite {
       RedisStream.XAddMessage("baf", List("1" -> "1")),
       RedisStream.XAddMessage("baz", List("2" -> "2")),
       RedisStream.XAddMessage("bar", List("3" -> "3")),
+      RedisStream.XAddMessage("baf", List("4" -> "4")),
+      RedisStream.XAddMessage("baz", List("5" -> "5")),
+      RedisStream.XAddMessage("bar", List("6" -> "6")),
     )
     redisConnection().flatMap{connection => 
       
       val rStream = RedisStream.fromConnection(connection)
       rStream.append(messages) >>
       rStream
-        .read(Set("baf", "baz", "bar"), stream => RedisCommands.StreamOffset.From(stream, "0"))
-        .take(3)
+        .read(Set("baf", "baz", "bar"), stream => RedisCommands.StreamOffset.From(stream, "0"), Duration.Zero, 1L.some)
+        .take(6)
         .compile
         .toList
 
     }.map{ resps => 
       val records = resps.flatMap(_.records).flatMap(_.keyValues.map(_._1)).toSet
-      assertEquals(records, Set("1", "2", "3"))
+      assertEquals(records, Set("1", "2", "3", "4", "5", "6"))
     }
   }
 }


### PR DESCRIPTION
When subscribing to multiple streams, if we begin with the same offset for all streams like for example `0-0`, it should have still appended 3 offsets instead of 1 to the `XREAD` command. 

This issue was due to use of `.map` operation when mapping to offset from `Set[StreamOffset]`