### PR TITLE
Update RedisStreamSpec.scala

### DIFF
--- a/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/rediculous/RedisStreamSpec.scala
@@ -69,9 +69,7 @@ class RedisStreamSpec extends CatsEffectSuite {
       rStream.append(messages) >>
       rStream
         .read(Set("fee"), (_ => RedisCommands.StreamOffset.From("fee", "0-0")), Duration.Zero, 1L.some)
-        .take(4)
-        .timeout(250.milli)
-        .handleErrorWith(_ => fs2.Stream.empty)
+        .take(3)
         .compile
         .toList
 


### PR DESCRIPTION
Since message count of 1 should force `XREAD` to return message count of 1 this should be sufficient to tests the subscription continuity. I forgot to update in my previous PR.