### PR TITLE
Added all XINFO and SCAN commands

### DIFF
--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisArg.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisArg.scala
@@ -1,6 +1,7 @@
 package io.chrisdavenport.rediculous
 
 import cats.Contravariant
+import io.chrisdavenport.rediculous.RedisProtocol.RedisType
 
 trait RedisArg[A]{
   def encode(a: A): String
@@ -35,4 +36,16 @@ object RedisArg {
       else a.toString()
   }
 
+  implicit val `type`: RedisArg[RedisType] = new RedisArg[RedisType] {
+    def encode(a: RedisType): String = 
+      a match {
+        case RedisProtocol.RedisType.String => "string"
+        case RedisProtocol.RedisType.Hash => "hash"
+        case RedisProtocol.RedisType.List => "list"
+        case RedisProtocol.RedisType.Set => "set"
+        case RedisProtocol.RedisType.Stream => "stream"
+        case RedisProtocol.RedisType.ZSet => "zset" 
+        case _ => throw RedisError.Generic(s"Rediculous: Cannot encode $a")
+      }
+  }
 }

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -981,6 +981,13 @@ object RedisCommands {
   def psetex[F[_]: RedisCtx](key: String, milliseconds: Long, value: String): F[Status] = 
     RedisCtx[F].keyed(key, NEL.of("PSETEX", key.encode, milliseconds.encode, value.encode))
 
+  def scan[F[_]: RedisCtx](cursor: Long, patternOpt: Option[String] = None, countOpt: Option[Long] = None, typeOpt: Option[RedisType] = None): F[(Long, List[String])] = {
+    val pattern = patternOpt.toList.flatMap(l => List("MATCH", l.encode))
+    val count = countOpt.toList.flatMap(l => List("COUNT", l.encode))
+    val `type` = typeOpt.toList.flatMap(l => List("TYPE", l.encode))
+    RedisCtx[F].unkeyed(NEL("SCAN", cursor.encode :: pattern ::: count ::: `type`))
+  }
+
   def scard[F[_]: RedisCtx](key: String): F[Long] = 
     RedisCtx[F].keyed(key, NEL.of("SCARD", key.encode))
 

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -588,7 +588,7 @@ object RedisCommands {
                 case (st, ("pending", r)) => 
                   RedisResult[List[(String, Long, Long)]]
                     .decode(r)
-                    .map(v => st.copy(pending = v.map(ConsumerPel.tupled)))
+                    .map(v => st.copy(pending = v.map((ConsumerPel.apply _).tupled)))
                 case (st, (_, _)) => st.asRight
               }
             }
@@ -620,7 +620,7 @@ object RedisCommands {
                 case (info, ("pending", r)) => 
                   RedisResult[List[(String, String, Long, Long)]]
                     .decode(r)
-                    .map(v => info.copy(pending = v.map(GroupPel.tupled)))
+                    .map(v => info.copy(pending = v.map((GroupPel.apply _).tupled)))
                 case (info, ("consumers", r)) => 
                   RedisResult[List[Consumer]]
                     .decode(r)

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -435,7 +435,6 @@ object RedisCommands {
     RedisCtx[F].unkeyed(NEL.of("XPENDING", stream, groupName))
 
   // TOOD xpendingdetail
-  // TODO xinfo
 
   final case class XClaimArgs(
     minIdleTime: Long,
@@ -520,6 +519,210 @@ object RedisCommands {
 
   def xautoclaimdetail[F[_]: RedisCtx](stream: String, args: XAutoClaimArgs): F[XAutoClaimDetail] = 
     xautoclaimraw(stream, args, false)
+
+  final case class StreamInfo(
+    length: Long,
+    radixTreeKeys: Long,
+    radixTreeNodes: Long,
+    lastGeneratedId: String,
+    maxDeletedEntryId: String,
+    entriesAdded: Long,
+    groups: Long,
+    firstEntry: Option[StreamsRecord],
+    lastEntry: Option[StreamsRecord],
+    recordedFirstEntryId: String,
+  )
+  object StreamInfo {
+    val empty: StreamInfo = StreamInfo(0, 0, 0, "", "", 0, 0, None, None, "")
+
+    implicit val result: RedisResult[StreamInfo] = new RedisResult[StreamInfo] {
+      def decode(resp: Resp): Either[Resp, StreamInfo] = {
+        RedisResult[List[(String, Resp)]]
+          .decode(resp)
+          .flatMap{ kvs => 
+            kvs.foldLeftM[Either[Resp, *], StreamInfo](empty){
+              case (info, ("length", Resp.Integer(v))) => info.copy(length = v).asRight
+              case (info, ("radix-tree-keys", Resp.Integer(v))) => info.copy(radixTreeKeys = v).asRight
+              case (info, ("radix-tree-nodes", Resp.Integer(v))) => info.copy(radixTreeNodes = v).asRight
+              case (info, ("last-generated-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(lastGeneratedId = v))
+              case (info, ("max-deleted-entry-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(maxDeletedEntryId = v))
+              case (info, ("entries-added", Resp.Integer(v))) => info.copy(entriesAdded = v).asRight
+              case (info, ("groups", Resp.Integer(v))) => info.copy(groups = v).asRight
+              case (info, ("first-entry", r)) => RedisResult[Option[StreamsRecord]].decode(r).map(v => info.copy(firstEntry = v))
+              case (info, ("last-entry", r)) => RedisResult[Option[StreamsRecord]].decode(r).map(v => info.copy(lastEntry = v))
+              case (info, ("recorded-first-entry-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(recordedFirstEntryId = v))
+              case (info, (_,_)) => info.asRight
+            }
+          }
+      }
+    }
+  }
+  
+  final case class StreamInfoFull(
+    length: Long,
+    radixTreeKeys: Long,
+    radixTreeNodes: Long,
+    lastGeneratedId: String,
+    maxDeletedEntryId: String,
+    entriesAdded: Long,
+    entries: List[StreamsRecord],
+    groups: List[StreamInfoFull.ConsumerGroupInfo],
+    recordedFirstEntryId: String,
+  )
+
+  object StreamInfoFull {
+    final case class GroupPel(entryId: String, consumerName: String, deliveryTimeMs: Long, deliveryCount: Long)
+    final case class ConsumerPel(entryId: String, deliveryTimeMs: Long, deliveryCount: Long)
+    final case class Consumer(name: String, seenTimeMs: Long, pelCount: Long, pending: List[ConsumerPel])
+    object Consumer {
+      val empty: Consumer = Consumer("", 0, 0, Nil)
+      implicit val result: RedisResult[Consumer] = new RedisResult[Consumer] {
+        def decode(resp: Resp): Either[Resp,Consumer] = 
+          RedisResult[List[(String, Resp)]]
+            .decode(resp)
+            .flatMap{ kvs => 
+              kvs.foldLeftM[Either[Resp, *], Consumer](empty){
+                case (st, ("name", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => st.copy(name = v))
+                case (st, ("seen-time", Resp.Integer(v))) => st.copy(seenTimeMs = v).asRight
+                case (st, ("pel-count", Resp.Integer(v))) => st.copy(pelCount = v).asRight
+                case (st, ("pending", r)) => 
+                  RedisResult[List[(String, Long, Long)]]
+                    .decode(r)
+                    .map(v => st.copy(pending = v.map(ConsumerPel.tupled)))
+                case (st, (_, _)) => st.asRight
+              }
+            }
+      }
+    }
+
+    final case class ConsumerGroupInfo(
+      name: String,
+      lastDeliveredId: String,
+      entriesRead: Long,
+      lag: Long,
+      pelCount: Long,
+      pending: List[GroupPel],
+      consumers: List[Consumer]
+    )
+    object ConsumerGroupInfo {
+      val empty: ConsumerGroupInfo = ConsumerGroupInfo("", "", 0, 0, 0, List.empty, List.empty)
+      implicit val result: RedisResult[ConsumerGroupInfo] = new RedisResult[ConsumerGroupInfo] {
+        def decode(resp: Resp): Either[Resp, ConsumerGroupInfo] = {
+          RedisResult[List[(String, Resp)]]
+            .decode(resp)
+            .flatMap{ kvs => 
+              kvs.foldLeftM[Either[Resp, *], ConsumerGroupInfo](empty){
+                case (info, ("name", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(name = v))
+                case (info, ("last-delivered-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(lastDeliveredId = v))
+                case (info, ("entries-read", Resp.Integer(v))) => info.copy(entriesRead = v).asRight
+                case (info, ("lag", Resp.Integer(v))) => info.copy(lag = v).asRight
+                case (info, ("pel-count", Resp.Integer(v))) => info.copy(pelCount = v).asRight
+                case (info, ("pending", r)) => 
+                  RedisResult[List[(String, String, Long, Long)]]
+                    .decode(r)
+                    .map(v => info.copy(pending = v.map(GroupPel.tupled)))
+                case (info, ("consumers", r)) => 
+                  RedisResult[List[Consumer]]
+                    .decode(r)
+                    .map(v => info.copy(consumers = v))
+                case (info, (_, _)) => info.asRight
+              }
+            }
+        }
+      }
+    }
+
+    val empty: StreamInfoFull = StreamInfoFull(0, 0, 0, "", "", 0, List.empty, List.empty, "")
+    implicit val result: RedisResult[StreamInfoFull] = new RedisResult[StreamInfoFull] {
+      def decode(resp: Resp): Either[Resp, StreamInfoFull] = {
+        RedisResult[List[(String, Resp)]]
+          .decode(resp)
+          .flatMap{ kvs => 
+            kvs.foldLeftM[Either[Resp, *], StreamInfoFull](empty){
+              case (info, ("length", Resp.Integer(v))) => info.copy(length = v).asRight
+              case (info, ("radix-tree-keys", Resp.Integer(v))) => info.copy(radixTreeKeys = v).asRight
+              case (info, ("radix-tree-nodes", Resp.Integer(v))) => info.copy(radixTreeNodes = v).asRight
+              case (info, ("last-generated-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(lastGeneratedId = v))
+              case (info, ("max-deleted-entry-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(maxDeletedEntryId = v))
+              case (info, ("entries-added", Resp.Integer(v))) => info.copy(entriesAdded = v).asRight
+              case (info, ("entries", r)) => RedisResult[List[StreamsRecord]].decode(r).map(v => info.copy(entries = v))
+              case (info, ("groups", r)) => RedisResult[List[ConsumerGroupInfo]].decode(r).map(v => info.copy(groups = v))
+              case (info, ("recorded-first-entry-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(recordedFirstEntryId = v))
+              case (info, (_, _)) => info.asRight
+            }
+          }
+      }
+    }
+  }
+
+  private def xinfostreamraw[F[_]: RedisCtx, A: RedisResult](stream: String, fullOpt: Boolean, countOpt: Option[Int]): F[A] = {
+    val full = Alternative[List].guard(fullOpt).as("FULL")
+    val count = countOpt.toList.flatMap(c => List("COUNT", c.encode))
+    RedisCtx[F].unkeyed(NEL("XINFO", "STREAM" :: stream :: full ::: count))
+  }
+
+  def xinfostream[F[_]: RedisCtx](stream: String): F[StreamInfo] = 
+    xinfostreamraw(stream, false, None)
+
+  def xinfostreamfull[F[_]: RedisCtx](stream: String, countOpt: Option[Int] = None): F[StreamInfoFull] = 
+    xinfostreamraw(stream, true, countOpt)
+
+  final case class StreamConsumersInfo(
+    name: String,
+    pending: Long,
+    idleMs: Long
+  )
+  object StreamConsumersInfo {
+    val empty: StreamConsumersInfo = StreamConsumersInfo("", 0, 0)
+    implicit val result: RedisResult[StreamConsumersInfo] = new RedisResult[StreamConsumersInfo] {
+      def decode(resp: Resp): Either[Resp,StreamConsumersInfo] = 
+        RedisResult[List[(String, Resp)]]
+          .decode(resp)
+          .flatMap{ kvs => 
+            kvs.foldLeftM[Either[Resp, *], StreamConsumersInfo](empty){
+              case (info, ("name", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(name = v))
+              case (info, ("pending", Resp.Integer(v))) => info.copy(pending = v).asRight
+              case (info, ("idle", Resp.Integer(v))) => info.copy(idleMs = v).asRight
+              case (info, (_, _)) => info.asRight
+            }
+          }
+    }
+  }
+  
+  def xinfoconsumer[F[_]: RedisCtx](stream: String, groupName: String): F[List[StreamConsumersInfo]] = 
+    RedisCtx[F].unkeyed(NEL.of("XINFO", "CONSUMERS", stream, groupName))
+
+  final case class StreamGroupsInfo(
+    name: String,
+    consumers: Long,
+    pending: Long,
+    lastDeliveredId: String,
+    entriesRead: Long,
+    lag: Long
+  )
+
+  object StreamGroupsInfo {
+    val empty: StreamGroupsInfo = StreamGroupsInfo("", 0, 0, "", 0, 0)
+    implicit val result: RedisResult[StreamGroupsInfo] = new RedisResult[StreamGroupsInfo] {
+      def decode(resp: Resp): Either[Resp,StreamGroupsInfo] = 
+        RedisResult[List[(String, Resp)]]
+          .decode(resp)
+          .flatMap{ kvs => 
+            kvs.foldLeftM[Either[Resp, *], StreamGroupsInfo](empty){
+              case (info, ("name", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(name = v))
+              case (info, ("consumers", Resp.Integer(v))) => info.copy(consumers = v).asRight
+              case (info, ("pending", Resp.Integer(v))) => info.copy(pending = v).asRight
+              case (info, ("last-delivered-id", Resp.BulkString(Some(bv)))) => bv.decodeUtf8.leftMap(_ => resp).map(v => info.copy(lastDeliveredId = v))
+              case (info, ("entries-read", Resp.Integer(v))) => info.copy(entriesRead = v).asRight
+              case (info, ("lag", Resp.Integer(v))) => info.copy(lag = v).asRight
+              case (info, (_, _)) => info.asRight
+            }
+          }
+    }
+  }
+
+  def xinfogroup[F[_]: RedisCtx](stream: String): F[List[StreamGroupsInfo]] = 
+    RedisCtx[F].unkeyed(NEL.of("XINFO", "GROUPS", stream))
 
   def xdel[F[_]: RedisCtx](stream: String, messageIds: List[String]): F[Long] = 
     RedisCtx[F].unkeyed(NEL("XDEL", stream :: messageIds))

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisProtocol.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisProtocol.scala
@@ -15,6 +15,7 @@ object RedisProtocol {
     case object Hash extends RedisType
     case object List extends RedisType
     case object Set extends RedisType
+    case object Stream extends RedisType
     case object ZSet extends RedisType
   }
 

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
@@ -101,6 +101,26 @@ object RedisResult extends RedisResultLowPriority{
     }
   }
 
+  implicit def tuple3[A: RedisResult, B: RedisResult, C: RedisResult]: RedisResult[(A, B, C)] = new RedisResult[(A, B, C)] {
+    def decode(resp: Resp): Either[Resp,(A, B, C)] = resp match {
+      case Resp.Array(Some(x ::y :: z :: Nil)) => (RedisResult[A].decode(x), RedisResult[B].decode(y), RedisResult[C].decode(z)).tupled
+      case otherwise => Left(otherwise)
+    }
+  }
+
+  implicit def tuple4[A: RedisResult, B: RedisResult, C: RedisResult, D: RedisResult]: RedisResult[(A, B, C, D)] = new RedisResult[(A, B, C, D)] {
+    def decode(resp: Resp): Either[Resp,(A, B, C, D)] = resp match {
+      case Resp.Array(Some(a :: b :: c :: d :: Nil)) => 
+        (
+          RedisResult[A].decode(a), 
+          RedisResult[B].decode(b),
+          RedisResult[C].decode(c),
+          RedisResult[D].decode(d),
+        ).tupled
+      case otherwise => Left(otherwise)
+    }
+  }
+
   implicit def kv[K: RedisResult, V: RedisResult]: RedisResult[List[(K, V)]] = 
     new RedisResult[List[(K, V)]] {
       def decode(resp: Resp): Either[Resp,List[(K, V)]] = {

--- a/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
+++ b/core/src/main/scala/io/chrisdavenport/rediculous/RedisResult.scala
@@ -62,6 +62,7 @@ object RedisResult extends RedisResultLowPriority{
         case "hash" => RedisProtocol.RedisType.Hash
         case "list" => RedisProtocol.RedisType.List
         case "set" => RedisProtocol.RedisType.Set
+        case "stream" => RedisProtocol.RedisType.Stream
         case "zset" => RedisProtocol.RedisType.ZSet
         case _ => throw RedisError.Generic(s"Rediculous: Unhandled red type: $value")
       })

--- a/core/src/test/scala/io/chrisdavenport/rediculous/RedisCommandsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/rediculous/RedisCommandsSpec.scala
@@ -106,6 +106,42 @@ class RedisCommandsSpec extends CatsEffectSuite {
     }
   }
 
+  test("xack"){
+    redisConnection().flatMap{ connection => 
+      import RedisCommands._
+      val msg1 = "msg1" -> "msg1"
+      val msg2 = "msg2" -> "msg2"
+      val msg3 = "msg3" -> "msg3"
+
+      val extract = (resp: Option[List[XReadResponse]]) => 
+        resp.getOrElse(List.empty).flatMap(_.records).map(_.recordId)
+
+      val consumer = Consumer("group1", "consumer1")
+
+      val action = 
+        for {
+          _       <- xgroupcreate[RedisIO]("foo", "group1", "$", true)
+          id1     <- xadd[RedisIO]("foo", List(msg1))
+          id2     <- xadd[RedisIO]("foo", List(msg2))
+          id3     <- xadd[RedisIO]("foo", List(msg3))
+          result1 <- xreadgroup[RedisIO](consumer, Set(StreamOffset.From("foo", "0-0"))).map(extract)
+          _       =  assertEquals(result1, List.empty)      // group was never read so PEL is empty
+          acked1  <- xack[RedisIO]("foo", "group1", List(id1))
+          _       =  assertEquals(acked1, 0L)               // should return 0 as nothing is in PEL
+          result2 <- xreadgroup[RedisIO](consumer, Set(StreamOffset.LastConsumed("foo"))).map(extract)
+          _       =  assertEquals(result2, List(id1, id2, id3))
+          acked2  <- xack[RedisIO]("foo", "group1", List(id1))
+          _       =  assertEquals(acked2, 1L)               // should return 1 as 1 in PEL entry
+          result3 <- xreadgroup[RedisIO](consumer, Set(StreamOffset.From("foo", "0-0"))).map(extract)
+          _       =  assertEquals(result3, List(id2, id3))  
+          _       <- xgroupdestroy[RedisIO]("foo", "group1")
+          _       <- del[RedisIO]("foo")
+        } yield ()
+
+      action.run(connection)
+    }
+  }
+
   test("xpendingsummary"){
     redisConnection().flatMap{ connection => 
       val msg1 = "msg1" -> "msg1"
@@ -180,6 +216,62 @@ class RedisCommandsSpec extends CatsEffectSuite {
           _ <- del[RedisIO]("foo")
         } yield assertEquals(actual, XAutoClaimSummary("0-0", List(id1, id2, id3), List(id4)))
       action.run(connection)
+    }
+  }
+
+  test("xinfo consumer"){
+    redisConnection().flatMap{ connection => 
+      val action = 
+        for {
+          _ <- RedisCommands.xgroupcreate[RedisIO]("foo", "group1", "$", true)
+          _ <- RedisCommands.xadd[RedisIO]("foo", List("msg" -> "msg"))
+          _ <- RedisCommands.xreadgroup[RedisIO](RedisCommands.Consumer("group1", "consumer1"), Set(RedisCommands.StreamOffset.LastConsumed("foo")), RedisCommands.XReadOpts.default.copy(count = Some(1)))
+          info <- RedisCommands.xinfoconsumer[RedisIO]("foo", "group1")
+          _ <- RedisCommands.xgroupdestroy[RedisIO]("foo", "group1")
+          _ <- RedisCommands.del[RedisIO]("foo")
+        } yield info.map(_.name)
+
+      action
+        .run(connection)
+        .assertEquals(List("consumer1"))
+    }
+  }
+  
+  test("xinfo group"){
+    redisConnection().flatMap{ connection => 
+      val action = 
+        for {
+          _ <- RedisCommands.xgroupcreate[RedisIO]("foo", "group1", "$", true)
+          _ <- RedisCommands.xadd[RedisIO]("foo", List("msg" -> "msg"))
+          _ <- RedisCommands.xreadgroup[RedisIO](RedisCommands.Consumer("group1", "consumer1"), Set(RedisCommands.StreamOffset.LastConsumed("foo")), RedisCommands.XReadOpts.default.copy(count = Some(1)))
+          info <- RedisCommands.xinfogroup[RedisIO]("foo")
+          _ <- RedisCommands.xgroupdestroy[RedisIO]("foo", "group1")
+          _ <- RedisCommands.del[RedisIO]("foo")
+        } yield info.map(_.name)
+
+      action
+        .run(connection)
+        .assertEquals(List("group1"))
+    }
+  }
+
+  test("xinfo stream"){
+    redisConnection().flatMap{ connection => 
+      val action = 
+        for {
+          _ <- RedisCommands.xgroupcreate[RedisIO]("foo", "group1", "$", true)
+          _ <- RedisCommands.xadd[RedisIO]("foo", List("msg" -> "msg"))
+          _ <- RedisCommands.xreadgroup[RedisIO](RedisCommands.Consumer("group1", "consumer1"), Set(RedisCommands.StreamOffset.LastConsumed("foo")), RedisCommands.XReadOpts.default.copy(count = Some(1)))
+          info <- RedisCommands.xinfostream[RedisIO]("foo")
+          infoFull <- RedisCommands.xinfostreamfull[RedisIO]("foo")
+          _ <- RedisCommands.xgroupdestroy[RedisIO]("foo", "group1")
+          _ <- RedisCommands.del[RedisIO]("foo")
+        } yield (info, infoFull)
+
+      action
+        .run(connection)
+        .map{ case (i, f) => (i.length, f.length) }
+        .assertEquals((1L, 1L))
     }
   }
 }

--- a/core/src/test/scala/io/chrisdavenport/rediculous/RedisCommandsSpec.scala
+++ b/core/src/test/scala/io/chrisdavenport/rediculous/RedisCommandsSpec.scala
@@ -53,6 +53,17 @@ class RedisCommandsSpec extends CatsEffectSuite {
     }
   }
 
+  test("scan"){
+    redisConnection().flatMap{connection => 
+      val action = RedisCommands.set[RedisIO]("foo", "bar") >> 
+        RedisCommands.scan[RedisIO](0) <* 
+        RedisCommands.del[RedisIO]("foo")
+      action.run(connection)
+    }.map{
+      assertEquals(_, 0L -> List("foo"))
+    }
+  }
+
   test("xadd/xread parity"){
     redisConnection().flatMap{ connection => 
       val kv = "bar" -> "baz"


### PR DESCRIPTION
Along with tests. :) 

I think we'd probably need to break down `RedisCommands.scala` along with test spec into multiple files by group for easier maintenance in the future.
<img width="330" alt="image" src="https://user-images.githubusercontent.com/3408009/183702935-aed7ad65-512b-414e-a550-5d4d7541566e.png">
