### PR TITLE
Add Auth On Connection Initialization

### DIFF
--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisCommands.scala
@@ -40,7 +40,7 @@ object RedisCommands {
   def zrevrange[F[_]: RedisCtx](key: String, start: Long, stop: Long): F[List[String]] = 
     RedisCtx[F].keyed(key, NEL.of("ZREVRANGE", key.encode, start.encode, stop.encode))
 
-  def zrevrangewithscores[F[_]: RedisCtx](key: String, start: Long, stop: Long): F[List[(String, Double)]] = 
+  def zrevrangewithscores[F[_]: RedisCtx](key: String, start: Long, stop: Long): F[List[(String, Double)]] =
     RedisCtx[F].keyed(key, NEL.of("ZREVRANGE", key.encode, start.encode, stop.encode, "WITHSCORES"))
 
   def zrangebyscore[F[_]: RedisCtx](key: String, min: Double, max: Double): F[List[String]] = 
@@ -456,10 +456,18 @@ object RedisCommands {
     RedisCtx[F].unkeyed(NEL("XCLAIM", stream :: consumerFragment ::: minIdleTime ::: messageIds ::: argFragment))
   }
 
+  def auth[F[_]: RedisCtx](username: String, password: String): F[Status] = {
+    RedisCtx[F].unkeyed(NEL("AUTH", username :: password :: Nil))
+  }
+
+  def auth[F[_]: RedisCtx](password: String): F[Status] = {
+    RedisCtx[F].unkeyed(NEL("AUTH", password :: Nil))
+  }
+
   def xclaimsummary[F[_]: RedisCtx](stream: String, consumer: Consumer, args: XClaimArgs, messageIds: List[String]): F[List[String]] = 
     xclaimraw(stream, consumer, args, true, messageIds)
 
-  def xclaimdetail[F[_]: RedisCtx](stream: String, consumer: Consumer, args: XClaimArgs, messageIds: List[String]): F[List[StreamsRecord]] = 
+  def xclaimdetail[F[_]: RedisCtx](stream: String, consumer: Consumer, args: XClaimArgs, messageIds: List[String]): F[List[StreamsRecord]] =
     xclaimraw(stream, consumer, args, false, messageIds)
 
   final case class XAutoClaimArgs(

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -143,7 +143,7 @@ object RedisConnection{
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
-  private[rediculous] def direct[F[_]: Async]: DirectConnectionBuilder[F] =
+  def direct[F[_]: Async]: DirectConnectionBuilder[F] =
     direct(Async[F], Network.forAsync[F])
 
   class DirectConnectionBuilder[F[_]: Temporal: Network] private[RedisConnection](
@@ -216,7 +216,7 @@ object RedisConnection{
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
-  private def pool[F[_]: Async]: PooledConnectionBuilder[F] =
+  def pool[F[_]: Async]: PooledConnectionBuilder[F] =
     pool(Async[F], Network.forAsync[F])
 
   class PooledConnectionBuilder[F[_]: Temporal: Network] private[RedisConnection] (
@@ -299,7 +299,7 @@ object RedisConnection{
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
-  private[rediculous] def queued[F[_]: Async]: QueuedConnectionBuilder[F] =
+  def queued[F[_]: Async]: QueuedConnectionBuilder[F] =
     queued(Async[F], Network.forAsync[F])
 
   class QueuedConnectionBuilder[F[_]: Temporal : Network] private[RedisConnection](
@@ -432,7 +432,7 @@ object RedisConnection{
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
-  private[rediculous] def cluster[F[_]: Async]: ClusterConnectionBuilder[F] =
+  def cluster[F[_]: Async]: ClusterConnectionBuilder[F] =
     cluster(Async[F], Network[F])
 
   class ClusterConnectionBuilder[F[_]: Async: Network] private[RedisConnection] (

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -131,7 +131,7 @@ object RedisConnection{
     val useTLS: Boolean = false
   }
 
-  def direct[F[_]: Async: Network]: DirectConnectionBuilder[F] =
+  def direct[F[_]: Temporal: Network]: DirectConnectionBuilder[F] =
     new DirectConnectionBuilder(
       Network[F],
       Defaults.host,
@@ -142,10 +142,11 @@ object RedisConnection{
       Defaults.useTLS
     )
 
+  @deprecated("Use overload that takes a Network", "0.4.1")
   private[rediculous] def direct[F[_]: Async]: DirectConnectionBuilder[F] =
-    direct(Async[F], Network[F])
+    direct(Async[F], Network.forAsync[F])
 
-  class DirectConnectionBuilder[F[_]: Concurrent: Network] private[RedisConnection](
+  class DirectConnectionBuilder[F[_]: Temporal: Network] private[RedisConnection](
     private val sg: SocketGroup[F],
     val host: Host,
     val port: Port,
@@ -203,7 +204,7 @@ object RedisConnection{
       } yield RedisConnection.DirectConnection(out)
   }
 
-  def pool[F[_]: Async: Network]: PooledConnectionBuilder[F] =
+  def pool[F[_]: Temporal: Network]: PooledConnectionBuilder[F] =
     new PooledConnectionBuilder(
       Network[F],
       Defaults.host,
@@ -214,10 +215,11 @@ object RedisConnection{
       Defaults.useTLS,
     )
 
+  @deprecated("Use overload that takes a Network", "0.4.1")
   private def pool[F[_]: Async]: PooledConnectionBuilder[F] =
-    pool(Async[F], Network[F])
+    pool(Async[F], Network.forAsync[F])
 
-  class PooledConnectionBuilder[F[_]: Async: Network] private[RedisConnection] (
+  class PooledConnectionBuilder[F[_]: Temporal: Network] private[RedisConnection] (
     private val sg: SocketGroup[F],
     val host: Host,
     val port: Port,
@@ -282,7 +284,7 @@ object RedisConnection{
 
   }
 
-  def queued[F[_]: Async: Network]: QueuedConnectionBuilder[F] =
+  def queued[F[_]: Temporal: Network]: QueuedConnectionBuilder[F] =
     new QueuedConnectionBuilder(
       Network[F],
       Defaults.host,
@@ -296,10 +298,11 @@ object RedisConnection{
       Defaults.useTLS,
     )
 
+  @deprecated("Use overload that takes a Network", "0.4.1")
   private[rediculous] def queued[F[_]: Async]: QueuedConnectionBuilder[F] =
-    queued(Async[F], Network[F])
+    queued(Async[F], Network.forAsync[F])
 
-  class QueuedConnectionBuilder[F[_]: Async] private[RedisConnection](
+  class QueuedConnectionBuilder[F[_]: Temporal : Network] private[RedisConnection](
     private val sg: SocketGroup[F],
     val host: Host,
     val port: Port,
@@ -411,7 +414,7 @@ object RedisConnection{
     }
   }
 
-  def cluster[F[_]: Async: Network]: ClusterConnectionBuilder[F] =
+  def cluster[F[_]: Temporal: Network]: ClusterConnectionBuilder[F] =
     new ClusterConnectionBuilder(
       Network[F],
       Defaults.host,
@@ -428,10 +431,11 @@ object RedisConnection{
       Defaults.useTLS,
     )
 
+  @deprecated("Use overload that takes a Network", "0.4.1")
   private[rediculous] def cluster[F[_]: Async]: ClusterConnectionBuilder[F] =
     cluster(Async[F], Network[F])
 
-  class ClusterConnectionBuilder[F[_]: Async] private[RedisConnection] (
+  class ClusterConnectionBuilder[F[_]: Temporal: Network] private[RedisConnection] (
     private val sg: SocketGroup[F],
     val host: Host,
     val port: Port,

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/cluster/ClusterCommands.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/cluster/ClusterCommands.scala
@@ -7,6 +7,8 @@ import cats.effect._
 import com.comcast.ip4s._
 import scodec.bits.ByteVector
 import RedisCtx.syntax.all._
+import cats.effect.std.Random
+import cats.MonadThrow
 
 object ClusterCommands {
 

--- a/examples/src/main/scala/AuthExample.scala
+++ b/examples/src/main/scala/AuthExample.scala
@@ -1,0 +1,33 @@
+import cats.effect._
+
+object AuthExample extends IOApp.Simple {
+    import io.chrisdavenport.rediculous._
+    import com.comcast.ip4s._
+
+    val host = sys.env.get("REDIS_HOST")
+      .flatMap(Host.fromString)
+      .getOrElse(host"localhost")
+    val port = sys.env.get("REDIS_PORT")
+      .flatMap(Port.fromString)
+      .getOrElse(port"5432")
+    val pass = sys.env.get("REDIS_PASS")
+      .getOrElse(throw new RuntimeException("Missing REDIS_PASS variable"))
+
+    val conn: Resource[IO, RedisConnection[IO]] =
+      RedisConnection.queued[IO]
+        .withHost(host)
+        .withPort(port)
+        .withMaxQueued(10000)
+        .withWorkers(1)
+        .withAuth(None, pass)
+        .build
+
+    val auth = RedisCommands.auth[Redis[IO, *]](pass)
+    val command = RedisCommands.ping[Redis[IO, *]]
+    val prog = conn.use{ c =>
+        command.run(c)
+          .flatTap(IO.println)
+    }
+
+    def run = prog.void
+}

--- a/examples/src/main/scala/AuthExample.scala
+++ b/examples/src/main/scala/AuthExample.scala
@@ -20,6 +20,7 @@ object AuthExample extends IOApp.Simple {
         .withMaxQueued(10000)
         .withWorkers(1)
         .withAuth(None, pass)
+        .withTLS
         .build
 
     val auth = RedisCommands.auth[Redis[IO, *]](pass)


### PR DESCRIPTION
Adds
- Automatically Authed Connections
- Use TLS capabilities
- Automatically leveraging the system TLSContext rather than needing to be manually provided.