### PR TITLE
Encode Multiple Timeout Approaches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import com.typesafe.tools.mima.core._
 
-ThisBuild / tlBaseVersion := "0.5" // your current series x.y
+ThisBuild / tlBaseVersion := "0.6" // your current series x.y
 
 ThisBuild / organization := "io.chrisdavenport"
 ThisBuild / organizationName := "Christopher Davenport"
@@ -56,20 +56,6 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       "org.scalameta"               %%% "munit-scalacheck"            % "1.0.0-M10" % Test,
     ),
     libraryDependencies += "org.scodec" %%% "scodec-core" % (if (scalaVersion.value.startsWith("2.")) "1.11.10" else "2.2.2"),
-
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#ClusterConnectionBuilder.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#PooledConnectionBuilder.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#QueuedConnectionBuilder.this"),
-
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#DirectConnectionBuilder.this"),
-      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection"),
-      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection.explicitPipelineRequest"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection.explicitPipelineRequest$default$3"),
-      ProblemFilters.exclude[MissingFieldProblem]("io.chrisdavenport.rediculous.RedisConnection.TimeoutConnection"),
-
-    )
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)}
   ).jvmSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,11 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#DirectConnectionBuilder.this"),
       ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection"),
-      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection$")
+      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection.explicitPipelineRequest"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection.explicitPipelineRequest$default$3"),
+      ProblemFilters.exclude[MissingFieldProblem]("io.chrisdavenport.rediculous.RedisConnection.TimeoutConnection"),
+
     )
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)}

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,10 @@ lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#ClusterConnectionBuilder.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#PooledConnectionBuilder.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#QueuedConnectionBuilder.this"),
+
+      ProblemFilters.exclude[DirectMissingMethodProblem]("io.chrisdavenport.rediculous.RedisConnection#DirectConnectionBuilder.this"),
+      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection"),
+      ProblemFilters.exclude[MissingClassProblem]("io.chrisdavenport.rediculous.RedisConnection$TimeoutConnection$")
     )
   ).jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule)}

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisConnection.scala
@@ -144,11 +144,21 @@ object RedisConnection{
     val maxIdle: Int = 100
     val maxTotal: Int = 100
 
-    val commandTimeout: Duration = 30.seconds // If using a blocking operation this is likely inappropriate.
-    @deprecated("0.5.2", "Use Defaults.commandTimeout instead")
-    val requestTimeout: Duration = commandTimeout
+    // If using a blocking operation these is likely inappropriate.
+    // You want Command Timeout to be higher than RedisRequestTimeout
+    val ownedConnectionCommandTimeout: Duration = 10.seconds
+    val ownedConnectionRedisRequestTimeout: Duration = 5.seconds
 
-    val redisRequestTimeout = 20.seconds // If using a blocking operation this is likely inappropriate.
+    // If using a blocking operation this is likely inappropriate.
+    val sharedConnectionCommandTimeout: Duration = 5.seconds
+    val sharedConnectionRedisRequestTimeout: Duration = 5.seconds
+
+
+    @deprecated("0.5.2", "Use Defaults.ownedConnectionCommandTimeout or Defaults. instead")
+    val requestTimeout: Duration = 30.seconds
+
+
+
 
 
     // TODO config
@@ -164,8 +174,8 @@ object RedisConnection{
       TLSParameters.Default,
       None,
       Defaults.useTLS,
-      Defaults.commandTimeout,
-      Defaults.redisRequestTimeout,
+      Defaults.ownedConnectionCommandTimeout,
+      Defaults.ownedConnectionRedisRequestTimeout,
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
@@ -233,9 +243,9 @@ object RedisConnection{
         _ <- Resource.eval(auth match {
           case None => ().pure[F]
           case Some((Some(username), password)) =>
-            RedisCommands.auth[Redis[F, *]](username, password).run(DirectConnection(out, commandTimeout, redisRequestTimeout)).void
+            RedisCommands.auth[Redis[F, *]](username, password).run(DirectConnection(out, Duration.Inf, redisRequestTimeout)).void
           case Some((None, password)) =>
-            RedisCommands.auth[Redis[F, *]](password).run(DirectConnection(out, commandTimeout, redisRequestTimeout)).void
+            RedisCommands.auth[Redis[F, *]](password).run(DirectConnection(out, Duration.Inf, redisRequestTimeout)).void
         })
       } yield RedisConnection.DirectConnection(out, commandTimeout, redisRequestTimeout)
   }
@@ -252,8 +262,8 @@ object RedisConnection{
       Defaults.idleTimeAllowedInPool,
       Defaults.maxIdle,
       Defaults.maxTotal,
-      Defaults.commandTimeout,
-      Defaults.redisRequestTimeout,
+      Defaults.ownedConnectionCommandTimeout,
+      Defaults.ownedConnectionRedisRequestTimeout,
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
@@ -338,9 +348,9 @@ object RedisConnection{
             auth match {
               case None => ().pure[F]
               case Some((Some(username), password)) =>
-                RedisCommands.auth[Redis[F, *]](username, password).run(DirectConnection(socket, commandTimeout, redisRequestTimeout)).void
+                RedisCommands.auth[Redis[F, *]](username, password).run(DirectConnection(socket, Duration.Inf, redisRequestTimeout)).void
               case Some((None, password)) =>
-                RedisCommands.auth[Redis[F, *]](password).run(DirectConnection(socket, commandTimeout, redisRequestTimeout)).void
+                RedisCommands.auth[Redis[F, *]](password).run(DirectConnection(socket, Duration.Inf, redisRequestTimeout)).void
             }
           )
         }
@@ -368,8 +378,8 @@ object RedisConnection{
       Defaults.idleTimeAllowedInPool,
       Defaults.maxIdle,
       Defaults.maxTotal,
-      Defaults.commandTimeout,
-      Defaults.redisRequestTimeout,
+      Defaults.sharedConnectionCommandTimeout,
+      Defaults.sharedConnectionRedisRequestTimeout,
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")
@@ -537,8 +547,8 @@ object RedisConnection{
       Defaults.idleTimeAllowedInPool,
       Defaults.maxIdle,
       Defaults.maxTotal,
-      Defaults.commandTimeout,
-      Defaults.redisRequestTimeout,
+      Defaults.sharedConnectionCommandTimeout,
+      Defaults.sharedConnectionRedisRequestTimeout,
     )
 
   @deprecated("Use overload that takes a Network", "0.4.1")

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisError.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisError.scala
@@ -1,5 +1,8 @@
 package io.chrisdavenport.rediculous
 
+import scala.concurrent.duration.Duration
+import java.util.concurrent.TimeoutException
+
 /** Indicates a Error while processing for Rediculous */
 trait RedisError extends RuntimeException {
 
@@ -23,4 +26,11 @@ object RedisError {
     override val message: String = s"Error encountered in queue: ${baseCase.getMessage()}"
     override val cause: Option[Throwable] = Some(baseCase)
   }
+
+  // TODO
+  trait RedisTimeoutException
+
+  final case class CommandTimeoutException(timeout: Duration) extends TimeoutException(s"Redis Command Timed Out: $timeout") with RedisTimeoutException
+  final case class RedisRequestTimeoutException(timeout: Duration) extends TimeoutException(s"Redis Request Timed Out: $timeout") with RedisTimeoutException
+
 }

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisPubSub.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisPubSub.scala
@@ -245,7 +245,7 @@ object RedisPubSub {
           }
         }
       }
-    case RedisConnection.DirectConnection(s, _, _) => 
+    case RedisConnection.DirectConnection(s, _, _) =>
       val messagesR = Concurrent[F].ref(Map[String, RedisPubSub.PubSubMessage => F[Unit]]())
       val onNonMessageR = Concurrent[F].ref((_: PubSubReply) => Applicative[F].unit)
       val onUnhandledMessageR = Concurrent[F].ref((_: PubSubMessage) => Applicative[F].unit)
@@ -254,7 +254,7 @@ object RedisPubSub {
         pubsub => pubsub.unsubscribeAll
       }
       }
-    case RedisConnection.Cluster(_, topology, sockets) => 
+    case RedisConnection.Cluster(_, topology, sockets, _) =>
       val messagesR = Concurrent[F].ref(Map[String, RedisPubSub.PubSubMessage => F[Unit]]())
       val onNonMessageR = Concurrent[F].ref((_: PubSubReply) => Applicative[F].unit)
       val onUnhandledMessageR = Concurrent[F].ref((_: PubSubMessage) => Applicative[F].unit)

--- a/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisPubSub.scala
+++ b/core/shared/src/main/scala/io/chrisdavenport/rediculous/RedisPubSub.scala
@@ -220,20 +220,20 @@ object RedisPubSub {
    * connections to all nodes.
    **/
   def fromConnection[F[_]: Concurrent](connection: RedisConnection[F], maxBytes: Int = 8096, clusterBroadcast: Boolean = false): Resource[F, RedisPubSub[F]] = connection match {
-    case RedisConnection.TimeoutConnection(conn, _) => fromConnection(conn, maxBytes, clusterBroadcast)
-    case RedisConnection.Queued(_, sockets) => 
+    // case RedisConnection.TimeoutConnection(conn, _, _, _) => fromConnection(conn, maxBytes, clusterBroadcast)
+    case RedisConnection.Queued(_, sockets, _) =>
       sockets.flatMap{managed => 
         val messagesR = Concurrent[F].ref(Map[String, RedisPubSub.PubSubMessage => F[Unit]]())
         val onNonMessageR = Concurrent[F].ref((_: PubSubReply) => Applicative[F].unit)
         val onUnhandledMessageR = Concurrent[F].ref((_: PubSubMessage) => Applicative[F].unit)
-        Resource.eval((messagesR, onNonMessageR, onUnhandledMessageR).tupled).flatMap{case (ref, onNonMessage, onUnhandledMessage) => 
+        Resource.eval((messagesR, onNonMessageR, onUnhandledMessageR).tupled).flatMap{case (ref, onNonMessage, onUnhandledMessage) =>
           Resource.makeCase(socket(connection, managed.value :: Nil, maxBytes, onNonMessage, onUnhandledMessage, ref).pure[F]){
             case (_, Resource.ExitCase.Errored(_)) | (_, Resource.ExitCase.Canceled) => managed.canBeReused.set(Reusable.DontReuse)
             case (pubsub, Resource.ExitCase.Succeeded) =>  pubsub.unsubscribeAll
           }
         }
       }
-    case RedisConnection.PooledConnection(pool) => 
+    case RedisConnection.PooledConnection(pool, _, _) =>
       pool.take(()).flatMap{managed =>
         val messagesR = Concurrent[F].ref(Map[String, RedisPubSub.PubSubMessage => F[Unit]]())
         val onNonMessageR = Concurrent[F].ref((_: PubSubReply) => Applicative[F].unit)
@@ -245,7 +245,7 @@ object RedisPubSub {
           }
         }
       }
-    case RedisConnection.DirectConnection(s) => 
+    case RedisConnection.DirectConnection(s, _, _) => 
       val messagesR = Concurrent[F].ref(Map[String, RedisPubSub.PubSubMessage => F[Unit]]())
       val onNonMessageR = Concurrent[F].ref((_: PubSubReply) => Applicative[F].unit)
       val onUnhandledMessageR = Concurrent[F].ref((_: PubSubMessage) => Applicative[F].unit)

--- a/core/shared/src/test/scala/io/chrisdavenport/rediculous/BufferedSocket.scala
+++ b/core/shared/src/test/scala/io/chrisdavenport/rediculous/BufferedSocket.scala
@@ -1,11 +1,9 @@
 package io.chrisdavenport.rediculous.util
 
-import cats._
 import cats.syntax.all._
 import fs2._
 import fs2.io.net.Socket
 import cats.effect._
-import cats.effect.std.Queue
 import com.comcast.ip4s.{IpAddress, SocketAddress}
 
 private[rediculous] trait BufferedSocket[F[_]] extends Socket[F]{
@@ -30,12 +28,12 @@ private[rediculous] object BufferedSocket{
 
     // This can return more bytes than max bytes, may want to refine this later
     def read(maxBytes: Int): F[Option[Chunk[Byte]]] = takeBuffer.flatMap{
-      case s@Some(value) => value.some.pure[F]
+      case Some(value) => value.some.pure[F]
       case None => socket.read(maxBytes)
     }
     
     def readN(numBytes: Int): F[Chunk[Byte]] = takeBuffer.flatMap{
-      case s@Some(value) => value.pure[F]
+      case Some(value) => value.pure[F]
       case None => socket.readN(numBytes)
     }
     
@@ -53,7 +51,7 @@ private[rediculous] object BufferedSocket{
     
     def write(bytes: Chunk[Byte]): F[Unit] = socket.write(bytes)
     
-    def writes: Pipe[F,Byte,INothing] = socket.writes
+    def writes: Pipe[F,Byte,Nothing] = socket.writes
     
   }
 

--- a/core/shared/src/test/scala/io/chrisdavenport/rediculous/RedisConnectionSpec.scala
+++ b/core/shared/src/test/scala/io/chrisdavenport/rediculous/RedisConnectionSpec.scala
@@ -18,7 +18,7 @@ class RedisConnectionSpec extends RediculousCrossSuite {
       def endOfInput: IO[Unit] = ???
 
       def endOfOutput: IO[Unit] = ???
-      
+
       def isOpen: IO[Boolean] = ???
       
       def remoteAddress: IO[SocketAddress[IpAddress]] = ???
@@ -37,7 +37,7 @@ class RedisConnectionSpec extends RediculousCrossSuite {
       def server(address: Option[Host], port: Option[Port], options: List[SocketOption]): fs2.Stream[IO,Socket[IO]] = ???
       
       def serverResource(address: Option[Host], port: Option[Port], options: List[SocketOption]): Resource[IO,(SocketAddress[IpAddress], fs2.Stream[IO,Socket[IO]])] = ???
-      
+
     }
 
     RedisConnection.queued[IO].withSocketGroup(sg).build


### PR DESCRIPTION
Splits Timeouts for RedisRequest (the time to interact with redis), CommandTimeout (the time for a user to wait for a command to return). Where this is slightly awkward is the fact that on Queued/Cluster you want Command to be shorter than RedisRequest, since they are unrelated. Whereas on Pooled/Direct you want Command to be longer than the request since if you cancel the command it will cancel before that is seen and hence returned to the pool. Since that signal cant be intercepted to prevent its reuse.

Finally we massively tune down the default timeouts. If you are using blocking operations, then you should use different defaults, but in most cases folks use blocking operations less these days in my experience.